### PR TITLE
Implement mask and validate commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# compiled executable
+regexp_utility

--- a/README.md
+++ b/README.md
@@ -1,2 +1,85 @@
-# regexp-utility
-Utility to censor chat message content using regular expressions
+# Glia Regexp Utility
+
+Glia Regex Utility is a small executable that is meant to accomplish two things:
+- Mask PII in chat messages using regular expressions provided by clients
+- Validate regular expressions provided by clients
+
+This executable is meant to be a very lightweight, is using only Golang's standard
+library and has zero external dependencies.
+
+## Usage
+
+Sub-commands and their flags can be seen by executing one of the following commands.
+
+```
+./regexp_utility --help
+./regexp_utility mask --help
+./regexp_utility validate --help
+```
+
+### Input masking
+
+```bash
+./regexp_utility mask \
+    --input "My SSN is 111-12-1234 and my code is secret" \
+    --regexp "secret" \
+    --regexp "(?:00[1-9]|0[1-9][0-9]|[1-578][0-9]{2}|6[0-57-9][0-9]|66[0-57-9])-(?:0[1-9]|[1-9]0|[1-9][1-9])-(?:[1-9][0-9][0-9][0-9]|[0-9][1-9][0-9][0-9]|[0-9][0-9][1-9][0-9]|[0-9][0-9][0-9][1-9])"
+```
+
+### Validating regex
+
+Valid regex example:
+
+```bash
+./regexp_utility validate --regexp "(abc|def)"
+```
+
+Invalid regex example (does not conform to RE2 syntax):
+
+```bash
+./regexp_utility validate --regexp '^((?!666|000)[0-8][0-9\_]{2}\-(?!00)[0-9\_]{2}\-(?!0000)[0-9\_]{4})*$'
+```
+
+## Development
+
+While developing the executable it is not necessary to build the executable every time. It is possible to use `go run`
+command with all the possible flags. For example:
+
+```bash
+go run regexp_utility.go validate --regexp "foo"
+```
+
+### Prerequisites
+
+To build the executable you need to have Go installed locally. This can be done by one of the following methods.
+There is no preference which method to use.
+
+#### Installing go using asdf
+
+NB! At the time of last update of this document the latest version of Go was `1.18`.
+Go versions are usually backwards compatible and it will most likely work with the newer version.
+
+`asdf plugin-add golang && asdf install golang 1.18 && asdf global golang 1.18`
+
+#### Installing go using Homebrew
+
+`brew install go`
+
+### Running tests
+
+`go test ./...` or `go test -v ./...` for verbose output
+
+### Building the executable
+
+To build executable on Mac the following command needs to be run in the project directory.
+
+```bash
+go build regex_utility.go
+```
+
+It is also possible to build an executable that can be run on Linux hosts. This can be useful to test the changes in
+DevSpaces with the new version of the executable. To build an executable for linux run the following command.
+
+```bash
+GOOS=linux GOARCH=amd64 go build regex_utility.go
+```

--- a/cmd/mask.go
+++ b/cmd/mask.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"regexp"
+)
+
+func Mask(input *string, regexpList *[]string) string {
+	inputBytes := []byte(*input)
+
+	for _, singleRegexp := range *regexpList {
+		compiledRegexp, err := regexp.Compile(singleRegexp)
+
+		if err != nil {
+			fmt.Printf("Failed to compile regexp '%s'", singleRegexp)
+			os.Exit(1)
+		}
+
+		inputBytes = compiledRegexp.ReplaceAllFunc(inputBytes, replaceWithAsterisks)
+	}
+
+	return string(inputBytes)
+}
+
+func replaceWithAsterisks(match []byte) []byte {
+	matchLength := len(match)
+	replacement := bytes.Repeat([]byte("*"), matchLength)
+
+	return replacement
+}

--- a/cmd/mask_test.go
+++ b/cmd/mask_test.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+)
+
+func TestMaskWithSingleRegexp(t *testing.T) {
+	input := "foo bar baz"
+	regexpList := []string{"bar"}
+
+	expectedResult := "foo *** baz"
+
+	result := Mask(&input, &regexpList)
+
+	assertEquals(t, result, expectedResult)
+}
+
+func TestMaskRespectsCaseRegexp(t *testing.T) {
+	input := "foo bar baz BAR foo"
+	regexpList := []string{"bar"}
+
+	expectedResult := "foo *** baz BAR foo"
+
+	result := Mask(&input, &regexpList)
+
+	assertEquals(t, result, expectedResult)
+}
+
+func TestMaskWithMultipleRegexp(t *testing.T) {
+	input := "My secret is abcdefg and my number is 369!"
+	regexpList := []string{"abcdefg", "([(0-9)]{3})"}
+
+	expectedResult := "My secret is ******* and my number is ***!"
+
+	result := Mask(&input, &regexpList)
+
+	assertEquals(t, result, expectedResult)
+}
+
+func TestMaskWithMultipleRegexpAndMultipleOccurrences(t *testing.T) {
+	input := "My secret is \"abc\" and my number is 777 and code is defgh!"
+	regexpList := []string{"(abc|defgh)", "([(0-9)]{3})"}
+
+	expectedResult := "My secret is \"***\" and my number is *** and code is *****!"
+
+	result := Mask(&input, &regexpList)
+
+	assertEquals(t, result, expectedResult)
+}
+
+func TestRegexWithLookaround(t *testing.T) {
+	if os.Getenv("RUN_TEST") == "1" {
+		input := "Hello"
+		// SSN regex that uses features not supported by RE2
+		regexpList := []string{"^((?!666|000)[0-8][0-9\\_]{2}\\-(?!00)[0-9\\_]{2}\\-(?!0000)[0-9\\_]{4})*$"}
+		Mask(&input, &regexpList)
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestRegexWithLookaround")
+	cmd.Env = append(os.Environ(), "RUN_TEST=1")
+	err := cmd.Run()
+	if e, ok := err.(*exec.ExitError); ok && !e.Success() {
+		return
+	}
+
+	t.Fatalf("process exited with exit code %v, expected exit status 1", err)
+}

--- a/cmd/test_helper.go
+++ b/cmd/test_helper.go
@@ -1,0 +1,9 @@
+package cmd
+
+import "testing"
+
+func assertEquals(t *testing.T, result interface{}, expectedResult interface{}) {
+	if result != expectedResult {
+		t.Errorf("got %t, expected %t", result, expectedResult)
+	}
+}

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"regexp"
+)
+
+func Validate(regularExpression *string) bool {
+	_, err := regexp.Compile(*regularExpression)
+
+	if err != nil {
+		return false
+	}
+
+	return true
+}

--- a/cmd/validate_test.go
+++ b/cmd/validate_test.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestValidateWithValidRegexp(t *testing.T) {
+	regularExpression := "foo"
+
+	result := Validate(&regularExpression)
+	expectedResult := true
+
+	assertEquals(t, result, expectedResult)
+}
+
+func TestValidateWithRegexpWithLookaroundFeature(t *testing.T) {
+	regularExpression := "^((?!666|000)[0-8][0-9\\_]{2}\\-(?!00)[0-9\\_]{2}\\-(?!0000)[0-9\\_]{4})*$"
+
+	result := Validate(&regularExpression)
+	expectedResult := false
+
+	assertEquals(t, result, expectedResult)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module regexp_utility
+
+go 1.18

--- a/regexp_utility.go
+++ b/regexp_utility.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"regexp_utility/cmd"
+)
+
+type stringArrayFlags []string
+
+func (i *stringArrayFlags) Set(value string) error {
+	*i = append(*i, value)
+	return nil
+}
+
+// needed by flag
+func (i *stringArrayFlags) String() string {
+	return ""
+}
+
+func mask(input *string, regexpList *[]string) {
+	result := cmd.Mask(input, regexpList)
+	fmt.Print(result)
+}
+
+func validate(regularExpression *string) {
+	isValid := cmd.Validate(regularExpression)
+
+	if !isValid {
+		fmt.Print("Invalid regular expression")
+		os.Exit(1)
+	}
+}
+
+func main() {
+	// mask command flags
+	maskCmd := flag.NewFlagSet("mask", flag.ExitOnError)
+	maskInput := maskCmd.String("input", "", "string to mask")
+
+	var regexpList stringArrayFlags
+	maskCmd.Var(&regexpList, "regexp", "Regular expression to match against, multiple --regexp flags are allowed")
+
+	// validate command flags
+	validateCmd := flag.NewFlagSet("validate", flag.ExitOnError)
+	validateRegexp := validateCmd.String("regexp", "", "Regular expression to validate")
+
+	unexpectedCommandError := "Usage: regexp_utility <subcommand> --help\n\tavailable subcommands: mask, validate"
+
+	if len(os.Args) < 2 {
+		fmt.Println(unexpectedCommandError)
+		os.Exit(1)
+	}
+
+	switch os.Args[1] {
+	case "mask":
+		maskCmd.Parse(os.Args[2:])
+		regexpStringList := []string(regexpList)
+
+		if *maskInput == "" {
+			fmt.Println("Input cannot be empty")
+			os.Exit(1)
+		}
+
+		if len(regexpStringList) == 0 {
+			fmt.Println("At least one regular expression has to be specified")
+			os.Exit(1)
+		}
+
+		mask(maskInput, &regexpStringList)
+	case "validate":
+		validateCmd.Parse(os.Args[2:])
+
+		if *validateRegexp == "" {
+			fmt.Println("Regular expression cannot be empty")
+			os.Exit(1)
+		}
+
+		validate(validateRegexp)
+	default:
+		fmt.Println(unexpectedCommandError)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
Implement an executable that supports two commands - `mask` and
`validate`. This executable will be called from our services to mask
the chat message content using supplied regular expressions and to
validate regular expression before saving it to DB. Validation is
needed to make sure that the regular expression provided by the user
has valid RE2 syntax and doesn't use features that are not allowed in
RE2 (lookaround features that can cause ReDOS attacks).

AUTO-404