### PR TITLE
Add release action

### DIFF
--- a/.github/workflows/release-on-master-build.yml
+++ b/.github/workflows/release-on-master-build.yml
@@ -1,0 +1,60 @@
+name: Release on master build
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.18
+
+    - name: Create releases directory
+      run: mkdir releases
+
+    - name: Build for Linux (amd64)
+      run: go build -o ./releases/regexp_utility-$GOOS-$GOARCH regexp_utility.go
+      env:
+        GOOS: linux
+        GOARCH: amd64
+
+    - name: Build for Intel based Macs (amd64)
+      run: go build -o ./releases/regexp_utility-$GOOS-$GOARCH regexp_utility.go
+      env:
+        GOOS: darwin
+        GOARCH: amd64
+
+    - name: Build for Apple Silicon based Macs (arm64)
+      run: go build -o ./releases/regexp_utility-$GOOS-$GOARCH regexp_utility.go
+      env:
+        GOOS: darwin
+        GOARCH: arm64
+
+    - name: Generate release tag
+      id: gen_tag
+      run: |
+        SHORT_REV=$(git rev-parse --short "$GITHUB_SHA")
+        echo "::set-output name=release_tag::release-$SHORT_REV"
+
+    - name: Push new tag
+      run: |
+        git tag ${{ steps.gen_tag.outputs.release_tag }}
+        git push origin master ${{ steps.gen_tag.outputs.release_tag }}
+
+    - name: Create GitHub release
+      uses: softprops/action-gh-release@v1
+      with:
+        tag_name: ${{ steps.gen_tag.outputs.release_tag }}
+        generate_release_notes: true
+        files: |
+          releases/regexp_utility-linux-amd64
+          releases/regexp_utility-darwin-amd64
+          releases/regexp_utility-darwin-arm64


### PR DESCRIPTION
Whenever PR is merged to the `master` branch we want a GitHub Workflow
to trigger. The workflow will build executables for different OS
versions, create a release tag and a release on GitHub. This way we can
use the built executables in our applications.

**Note for reviewers:** the release will look like this, will remove it before merging this PR: https://github.com/salemove/regexp-utility/releases/tag/release-91c609e

AUTO-405