### PR TITLE
Fix masking for multibyte characters

### DIFF
--- a/cmd/mask.go
+++ b/cmd/mask.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"unicode/utf8"
 )
 
 func Mask(input *string, regexpList *[]string) string {
@@ -25,7 +26,7 @@ func Mask(input *string, regexpList *[]string) string {
 }
 
 func replaceWithAsterisks(match []byte) []byte {
-	matchLength := len(match)
+	matchLength := utf8.RuneCount(match)
 	replacement := bytes.Repeat([]byte("*"), matchLength)
 
 	return replacement

--- a/cmd/mask_test.go
+++ b/cmd/mask_test.go
@@ -17,6 +17,17 @@ func TestMaskWithSingleRegexp(t *testing.T) {
 	assertEquals(t, result, expectedResult)
 }
 
+func TestMaskWithMultibyteCharacters(t *testing.T) {
+	input := "Üks poiss läks üle silla"
+	regexpList := []string{"(Ü|ü)"}
+
+	expectedResult := "*ks poiss läks *le silla"
+
+	result := Mask(&input, &regexpList)
+
+	assertEquals(t, result, expectedResult)
+}
+
 func TestMaskRespectsCaseRegexp(t *testing.T) {
 	input := "foo bar baz BAR foo"
 	regexpList := []string{"bar"}


### PR DESCRIPTION
Previously when regular expression tried to mask multibyte characters
(for example umlauts) then the length of the match was calculated
incorrectly. This commit fixes it.