### PR TITLE
Revamp local build and CI

### DIFF
--- a/.github/workflows/release-on-master-build.yml
+++ b/.github/workflows/release-on-master-build.yml
@@ -5,39 +5,67 @@ on:
     branches:
       - master
 
+env:
+  # Common versions
+  GO_VERSION: '1.22.4'
+  GOLANGCI_LINT_VERSION: '1.59.1'
+
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: ${{ env.GOLANGCI_VERSION }}
+
+      - name: Run quality control checks
+        run: make vet
+
+      - name: Run tests
+        run: make test
 
   build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        os:
+          - linux
+          - darwin
+        arch:
+          - amd64
+          - arm64
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
-        go-version: 1.18
+        go-version: ${{ env.GO_VERSION }}
 
     - name: Create releases directory
       run: mkdir releases
 
-    - name: Build for Linux (amd64)
-      run: go build -o ./releases/regexp_utility-$GOOS-$GOARCH regexp_utility.go
+    - name: Build
+      run: make build OUTPUT_PATH=releases/regexp_utility-${{ matrix.os }}-${{ matrix.arch }}
       env:
-        GOOS: linux
-        GOARCH: amd64
+        GOOS: ${{ matrix.os }}
+        GOARCH: ${{ matrix.arch }}
 
-    - name: Build for Intel based Macs (amd64)
-      run: go build -o ./releases/regexp_utility-$GOOS-$GOARCH regexp_utility.go
-      env:
-        GOOS: darwin
-        GOARCH: amd64
-
-    - name: Build for Apple Silicon based Macs (arm64)
-      run: go build -o ./releases/regexp_utility-$GOOS-$GOARCH regexp_utility.go
-      env:
-        GOOS: darwin
-        GOARCH: arm64
-
+  release:
+    runs-on: ubuntu-latest
+    needs:
+      - test
+      - build
+    steps:
     - name: Generate release tag
       id: gen_tag
       run: |
@@ -50,11 +78,9 @@ jobs:
         git push origin master ${{ steps.gen_tag.outputs.release_tag }}
 
     - name: Create GitHub release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       with:
         tag_name: ${{ steps.gen_tag.outputs.release_tag }}
         generate_release_notes: true
         files: |
-          releases/regexp_utility-linux-amd64
-          releases/regexp_utility-darwin-amd64
-          releases/regexp_utility-darwin-arm64
+          releases/regexp_utility-*

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,23 +8,34 @@ on:
     branches:
       - master
 
-jobs:
+env:
+  # Common versions
+  GO_VERSION: '1.22.4'
+  GOLANGCI_LINT_VERSION: 'v1.59.1'
 
+jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Set up Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.18
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: false  # The golangci-lint action does its own caching.
 
-    - name: Build
-      run: go build -v ./...
+      - name: Lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: ${{ env.GOLANGCI_VERSION }}
 
-    - name: Check formatting
-      run: files=$(gofmt -l .) && [ -z "$files" ]
+      - name: Run quality control checks
+        run: make vet
 
-    - name: Test
-      run: go test -v ./...
+      - name: Run tests
+        run: make test
+
+      - name: Build
+        run: make build

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-# compiled executable
-regexp_utility
+bin
+.cache

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,196 @@
+run:
+  allow-parallel-runners: true
+  timeout: 5m
+  concurrency: 4
+
+output:
+  # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
+  formats:
+    - format: colored-line-number
+
+linters-settings:
+  errcheck:
+    # report about not checking of errors in type assetions: `a := b.(MyStruct)`;
+    # default is false: such cases aren't reported by default.
+    check-type-assertions: false
+
+    # report about assignment of errors to blank identifier: `num, _ := strconv.Atoi(numStr)`;
+    # default is false: such cases aren't reported by default.
+    check-blank: false
+
+  govet:
+    # report about shadowed variables
+    check-shadowing: false
+
+  gofmt:
+    # simplify code: gofmt with `-s` option, true by default
+    simplify: true
+
+  gci:
+    custom-order: true
+    sections:
+      - standard
+      - default
+      - blank
+      - dot
+
+  gocyclo:
+    # minimal code complexity to report, 30 by default (but we recommend 10-20)
+    min-complexity: 10
+
+  maligned:
+    # print struct with more effective memory layout or not, false by default
+    suggest-new: true
+
+  dupl:
+    # tokens count to trigger issue, 150 by default
+    threshold: 100
+
+  goconst:
+    # minimal length of string constant, 3 by default
+    min-len: 3
+    # minimal occurrences count to trigger, 3 by default
+    min-occurrences: 5
+
+  lll:
+    # tab width in spaces. Default to 1.
+    tab-width: 1
+
+  unparam:
+    # Inspect exported functions, default is false. Set to true if no external program/library imports your code.
+    # XXX: if you enable this setting, unparam will report a lot of false-positives in text editors:
+    # if it's called for subdir of a project it can't find external interfaces. All text editor integrations
+    # with golangci-lint call it on a directory with the changed file.
+    check-exported: false
+
+  nakedret:
+    # make an issue if func has more lines of code than this setting and it has naked returns; default is 30
+    max-func-lines: 30
+
+  prealloc:
+    # XXX: we don't recommend using this linter before doing performance profiling.
+    # For most programs usage of prealloc will be a premature optimization.
+
+    # Report preallocation suggestions only on simple loops that have no returns/breaks/continues/gotos in them.
+    # True by default.
+    simple: true
+    range-loops: true # Report preallocation suggestions on range loops, true by default
+    for-loops: false # Report preallocation suggestions on for loops, false by default
+
+  gocritic:
+    # Enable multiple checks by tags, run `GL_DEBUG=gocritic golangci-lint` run to see all tags and checks.
+    # Empty list by default. See https://github.com/go-critic/go-critic#usage -> section "Tags".
+    enabled-tags:
+      - performance
+
+    settings: # settings passed to gocritic
+      captLocal: # must be valid enabled check name
+        paramsOnly: true
+      rangeValCopy:
+        sizeThreshold: 32
+
+  nolintlint:
+    require-explanation: true
+    require-specific: true
+
+
+linters:
+  enable:
+    - govet
+    - gocyclo
+    - gocritic
+    - goconst
+    - gosimple
+    - gci
+    - gofmt  # We enable this as well as goimports for its simplify mode.
+    - prealloc
+    - unconvert
+    - misspell
+    - nakedret
+    - nolintlint
+    - staticcheck
+    - unused
+
+  presets:
+    - bugs
+    - unused
+  fast: false
+
+
+issues:
+  exclude-files:
+    - "zz_generated\\..+\\.go$"
+
+  # Excluding configuration per-path and per-linter
+  exclude-rules:
+    # Exclude some linters from running on tests files.
+    - path: _test(ing)?\.go
+      linters:
+        - gocyclo
+        - errcheck
+        - dupl
+        - gosec
+        - scopelint
+        - unparam
+
+    # Ease some gocritic warnings on test files.
+    - path: _test\.go
+      text: "(unnamedResult|exitAfterDefer)"
+      linters:
+        - gocritic
+
+    # These are performance optimisations rather than style issues per se.
+    # They warn when function arguments or range values copy a lot of memory
+    # rather than using a pointer.
+    - text: "(hugeParam|rangeValCopy):"
+      linters:
+      - gocritic
+
+    # This "TestMain should call os.Exit to set exit code" warning is not clever
+    # enough to notice that we call a helper method that calls os.Exit.
+    - text: "SA3000:"
+      linters:
+      - staticcheck
+
+    - text: "k8s.io/api/core/v1"
+      linters:
+      - goimports
+
+    # This is a "potential hardcoded credentials" warning. It's triggered by
+    # any variable with 'secret' in the same, and thus hits a lot of false
+    # positives in Kubernetes land where a Secret is an object type.
+    - text: "G101:"
+      linters:
+      - gosec
+      - gas
+
+    # This is an 'errors unhandled' warning that duplicates errcheck.
+    - text: "G104:"
+      linters:
+      - gosec
+      - gas
+
+    # Some k8s dependencies do not have JSON tags on all fields in structs.
+    - path: k8s.io/
+      linters:
+      - musttag
+
+  # Independently from option `exclude` we use default exclude patterns,
+  # it can be disabled by this option. To list all
+  # excluded by default patterns execute `golangci-lint run --help`.
+  # Default value for this option is true.
+  exclude-use-default: false
+
+  # Show only new issues: if there are unstaged changes or untracked files,
+  # only those changes are analyzed, else only changes in HEAD~ are analyzed.
+  # It's a super-useful option for integration of golangci-lint into existing
+  # large codebase. It's not practical to fix all existing issues at the moment
+  # of integration: much better don't allow issues in new code.
+  # Default is false.
+  new: false
+
+  # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
+  max-per-linter: 0
+
+  # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
+  max-same-issues: 0

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,90 @@
+PROJECT_NAME = regexp_utility
+OUTPUT_PATH ?= bin/$(PROJECT_NAME)
+
+# ==================================================================================== #
+# HELPERS
+# ==================================================================================== #
+
+## help: print this help message
+.PHONY: help
+help:
+	@echo 'Usage:'
+	@sed -n 's/^##//p' ${MAKEFILE_LIST} | column -t -s ':' |  sed -e 's/^/ /'
+
+# ==================================================================================== #
+# QUALITY CONTROL
+# ==================================================================================== #
+
+## tidy: format code and tidy modfile
+.PHONY: tidy
+tidy:
+	go fmt ./...
+	go mod tidy -v
+
+## audit: run quality control checks
+.PHONY: audit
+audit: vet lint
+
+## vet: examine Go source code and report suspicious constructs
+.PHONY: vet
+vet:
+	@go mod verify
+	@go vet ./...
+
+## lint: run various Go source code linters
+.PHONY: lint
+lint: golangci-lint
+	@$(GOLANGCI_LINT) run
+
+## lint.fix: run various Go source code linters and automatically fix warnings
+.PHONY: lint.fix
+lint.fix: golangci-lint
+	@$(GOLANGCI_LINT) run --fix
+
+# ==================================================================================== #
+# DEVELOPMENT
+# ==================================================================================== #
+
+## test: run all tests
+.PHONY: test
+test:
+	@go test -v -race -buildvcs ./...
+
+
+## build: build the application
+.PHONY: build
+build:
+	@mkdir -p $(dir $(OUTPUT_PATH))
+	@go build -o $(OUTPUT_PATH) .
+
+
+# ==================================================================================== #
+# LOCAL TOOLS
+# ==================================================================================== #
+
+TOOLS_DIR ?= $(shell pwd)/.cache/tools
+
+GOLANGCI_LINT_VERSION ?= v1.59.1
+GOLANGCI_LINT = $(TOOLS_DIR)/golangci-lint-$(GOLANGCI_LINT_VERSION)
+
+## golangci-lint: download golangci-lint locally if necessary.
+golangci-lint: $(GOLANGCI_LINT)
+$(GOLANGCI_LINT): $(TOOLS_DIR)
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,${GOLANGCI_LINT_VERSION})
+
+$(TOOLS_DIR):
+	@mkdir -p $(TOOLS_DIR)
+
+# go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
+# $1 - target path with name of binary (ideally with version)
+# $2 - package url which can be installed
+# $3 - specific version of package
+define go-install-tool
+@[ -f $(1) ] || { \
+set -e; \
+package=$(2)@$(3) ;\
+echo "Downloading $${package}" ;\
+GOBIN=$(TOOLS_DIR) go install $${package} ;\
+mv "$$(echo "$(1)" | sed "s/-$(3)$$//")" $(1) ;\
+}
+endef

--- a/README.md
+++ b/README.md
@@ -12,15 +12,15 @@ library and has zero external dependencies.
 Sub-commands and their flags can be seen by executing one of the following commands.
 
 ```
-./regexp_utility --help
-./regexp_utility mask --help
-./regexp_utility validate --help
+bin/regexp_utility --help
+bin/regexp_utility mask --help
+bin/regexp_utility validate --help
 ```
 
 ### Input masking
 
 ```bash
-./regexp_utility mask \
+bin/regexp_utility mask \
     --input "My SSN is 111-12-1234 and my code is secret" \
     --regexp "secret" \
     --regexp "(?:00[1-9]|0[1-9][0-9]|[1-578][0-9]{2}|6[0-57-9][0-9]|66[0-57-9])-(?:0[1-9]|[1-9]0|[1-9][1-9])-(?:[1-9][0-9][0-9][0-9]|[0-9][1-9][0-9][0-9]|[0-9][0-9][1-9][0-9]|[0-9][0-9][0-9][1-9])"
@@ -31,13 +31,13 @@ Sub-commands and their flags can be seen by executing one of the following comma
 Valid regex example:
 
 ```bash
-./regexp_utility validate --regexp "(abc|def)"
+bin/regexp_utility validate --regexp "(abc|def)"
 ```
 
 Invalid regex example (does not conform to RE2 syntax):
 
 ```bash
-./regexp_utility validate --regexp '^((?!666|000)[0-8][0-9\_]{2}\-(?!00)[0-9\_]{2}\-(?!0000)[0-9\_]{4})*$'
+bin/regexp_utility validate --regexp '^((?!666|000)[0-8][0-9\_]{2}\-(?!00)[0-9\_]{2}\-(?!0000)[0-9\_]{4})*$'
 ```
 
 ## Development
@@ -46,7 +46,7 @@ While developing the executable it is not necessary to build the executable ever
 command with all the possible flags. For example:
 
 ```bash
-go run regexp_utility.go validate --regexp "foo"
+go run . validate --regexp "foo"
 ```
 
 ### Prerequisites
@@ -56,10 +56,10 @@ There is no preference which method to use.
 
 #### Installing go using asdf
 
-NB! At the time of last update of this document the latest version of Go was `1.18`.
+NB! At the time of last update of this document the latest version of Go was `1.22`.
 Go versions are usually backwards compatible and it will most likely work with the newer version.
 
-`asdf plugin-add golang && asdf install golang 1.18 && asdf global golang 1.18`
+`asdf plugin-add golang && asdf install golang 1.22 && asdf global golang 1.22`
 
 #### Installing go using Homebrew
 
@@ -67,19 +67,19 @@ Go versions are usually backwards compatible and it will most likely work with t
 
 ### Running tests
 
-`go test ./...` or `go test -v ./...` for verbose output
+Run `make test`.
 
 ### Building the executable
 
 To build executable on Mac the following command needs to be run in the project directory.
 
 ```bash
-go build regex_utility.go
+make build
 ```
 
 It is also possible to build an executable that can be run on Linux hosts. This can be useful to test the changes in
 DevSpaces with the new version of the executable. To build an executable for linux run the following command.
 
 ```bash
-GOOS=linux GOARCH=amd64 go build regex_utility.go
+GOOS=linux GOARCH=amd64 make build
 ```

--- a/cmd/mask_test.go
+++ b/cmd/mask_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"testing"
@@ -73,7 +74,8 @@ func TestRegexWithLookaround(t *testing.T) {
 	cmd := exec.Command(os.Args[0], "-test.run=TestRegexWithLookaround")
 	cmd.Env = append(os.Environ(), "RUN_TEST=1")
 	err := cmd.Run()
-	if e, ok := err.(*exec.ExitError); ok && !e.Success() {
+	var e *exec.ExitError
+	if errors.As(err, &e) && !e.Success() {
 		return
 	}
 

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -7,9 +7,5 @@ import (
 func Validate(regularExpression *string) bool {
 	_, err := regexp.Compile(*regularExpression)
 
-	if err != nil {
-		return false
-	}
-
-	return true
+	return err == nil
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module regexp_utility
 
-go 1.18
+go 1.22

--- a/regexp_utility.go
+++ b/regexp_utility.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+
 	"regexp_utility/cmd"
 )
 
@@ -54,7 +55,12 @@ func main() {
 
 	switch os.Args[1] {
 	case "mask":
-		maskCmd.Parse(os.Args[2:])
+		err := maskCmd.Parse(os.Args[2:])
+		if err != nil {
+			fmt.Printf("Cannot parse command-line arguments: %s\n", err)
+			os.Exit(1)
+		}
+
 		regexpStringList := []string(regexpList)
 
 		if *maskInput == "" {
@@ -69,7 +75,11 @@ func main() {
 
 		mask(maskInput, &regexpStringList)
 	case "validate":
-		validateCmd.Parse(os.Args[2:])
+		err := validateCmd.Parse(os.Args[2:])
+		if err != nil {
+			fmt.Printf("Cannot parse command-line arguments: %s\n", err)
+			os.Exit(1)
+		}
 
 		if *validateRegexp == "" {
 			fmt.Println("Regular expression cannot be empty")


### PR DESCRIPTION
This commit adds some improvements to the local development experience and adds more checks to CI.

Namely:
- `Makefile` with targets that make local development simpler: `make build`, `make test`, `make audit`, etc.
- Same checks are added to CI to ensure code quality for each PR.
- [golangci-lint][1] is added to the checks.
- Linter warnings are fixed.
- Tests are also run before the release.
- Go updated to 1.22.

[1]: https://github.com/golangci/golangci-lint