### PR TITLE
Fix Release action

### DIFF
--- a/.github/workflows/release-on-master-build.yml
+++ b/.github/workflows/release-on-master-build.yml
@@ -7,11 +7,11 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.22.4'
+  GO_VERSION: '1.22.5'
   GOLANGCI_LINT_VERSION: '1.59.1'
 
 jobs:
-  test:
+  release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -32,42 +32,32 @@ jobs:
       - name: Run tests
         run: make test
 
-  build:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-      matrix:
-        os:
-          - linux
-          - darwin
-        arch:
-          - amd64
-          - arm64
-    steps:
-    - uses: actions/checkout@v4
+      - name: Create releases directory
+        run: mkdir releases
 
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: ${{ env.GO_VERSION }}
+      - name: Build for Linux (amd64)
+        run: make build OUTPUT_PATH=releases/regexp_utility-$GOOS-$GOARCH
+        env:
+          GOOS: linux
+          GOARCH: amd64
 
-    - name: Create releases directory
-      run: mkdir releases
+      - name: Build for Linux (arm64)
+        run: make build OUTPUT_PATH=releases/regexp_utility-$GOOS-$GOARCH
+        env:
+          GOOS: linux
+          GOARCH: arm64
 
-    - name: Build
-      run: make build OUTPUT_PATH=releases/regexp_utility-${{ matrix.os }}-${{ matrix.arch }}
-      env:
-        GOOS: ${{ matrix.os }}
-        GOARCH: ${{ matrix.arch }}
+      - name: Build for Intel based Macs (amd64)
+        run: make build OUTPUT_PATH=releases/regexp_utility-$GOOS-$GOARCH
+        env:
+          GOOS: darwin
+          GOARCH: amd64
 
-  release:
-    runs-on: ubuntu-latest
-    needs:
-      - test
-      - build
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - name: Build for Apple Silicon based Macs (arm64)
+        run: make build OUTPUT_PATH=releases/regexp_utility-$GOOS-$GOARCH
+        env:
+          GOOS: darwin
+          GOARCH: arm64
 
       - name: Generate release tag
         id: gen_tag
@@ -86,4 +76,7 @@ jobs:
           tag_name: ${{ steps.gen_tag.outputs.release_tag }}
           generate_release_notes: true
           files: |
-            releases/regexp_utility-*
+            releases/regexp_utility-linux-amd64
+            releases/regexp_utility-linux-arm64
+            releases/regexp_utility-darwin-amd64
+            releases/regexp_utility-darwin-arm64

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.22.4'
+  GO_VERSION: '1.22.5'
   GOLANGCI_LINT_VERSION: 'v1.59.1'
 
 jobs:


### PR DESCRIPTION
Previously, the Ruild and Release steps were split into different jobs, but in GitHub actions, there is no shared workspace, so all the files generated in the Build step were lost and not included into the final release.

Revert to previous version of the Release action.