### PR TITLE
Update go from 1.22.5 to 1.22.7

### DIFF
--- a/.github/workflows/release-on-master-build.yml
+++ b/.github/workflows/release-on-master-build.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.22.5'
+  GO_VERSION: '1.22.7'
   GOLANGCI_LINT_VERSION: '1.59.1'
 
 jobs:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.22.5'
+  GO_VERSION: '1.22.7'
   GOLANGCI_LINT_VERSION: 'v1.59.1'
 
 jobs:


### PR DESCRIPTION
Version 1.22.5 has vulnerabilities, it's recommended to upgrade to v1.22.7 https://us2.app.sysdig.com/secure/#/vulnerabilities/results/17f38773955949648bdd7ae34927f0a0/content?filter=freeText+in+%28%22Go+1.22.5%22%29