### PR TITLE
Fix release-on-master-build workflow

### DIFF
--- a/.github/workflows/release-on-master-build.yml
+++ b/.github/workflows/release-on-master-build.yml
@@ -22,7 +22,7 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
 


### PR DESCRIPTION
golangci-lint-action needed to be bumped to v7