### PR TITLE
Upgrade go to v1.26.5

### DIFF
--- a/.github/workflows/release-on-master-build.yml
+++ b/.github/workflows/release-on-master-build.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.26.1'
+  GO_VERSION: '1.26.5'
   GOLANGCI_LINT_VERSION: 'v2.11.3'
 
 jobs:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.26.1'
+  GO_VERSION: '1.26.5'
   GOLANGCI_LINT_VERSION: 'v2.11.3'
 
 jobs:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.26.1
+golang 1.26.5


### PR DESCRIPTION
Version 1.26.1 has vulnerabilities, including high ones. Bump up version to get rid of them.